### PR TITLE
Fix filter queryparam not being removed after clearing the filter

### DIFF
--- a/pages/replays/components/MapFilter.vue
+++ b/pages/replays/components/MapFilter.vue
@@ -5,7 +5,7 @@
         </div>
         <div class="input" @click="isEnabled = true">
             <v-autocomplete ref="vAutocomplete" v-model="selectedItems" :items="items" item-text="scriptName" item-value="scriptName" auto-select-firstchips
-                clearable deletable-chips multiple dense small-chips @change="clear">
+                clearable deletable-chips multiple dense small-chips @change="onChange">
                 <template v-slot:item="data">
                     <v-list-item-content>
                         <v-list-item-title v-text="data.item.scriptName" />
@@ -20,7 +20,7 @@
 import { Component, Prop, Vue } from "nuxt-property-decorator";
 import _ from "lodash";
 
-@Component({ 
+@Component({
     fetchOnServer: false,
     watch: {
         isEnabled: function(this: MapFilterComponent) {
@@ -45,9 +45,9 @@ export default class MapFilterComponent extends Vue {
         this.items = players;
     }
 
-    clear() {
-        (this.$refs.vAutocomplete as any).lazySearch = ""; // temp fix for last text not clearing, fixed in latest vuetify
-        this.$emit("input", this.selectedItems);
+    onChange() {
+        (this.$refs.vAutocomplete as any).isMenuActive = false;
+        this.$emit("input", this.selectedItems?.length ? this.selectedItems : undefined);
     }
 }
 </script>

--- a/pages/replays/components/PlayerFilter.vue
+++ b/pages/replays/components/PlayerFilter.vue
@@ -21,7 +21,7 @@
                 small-chips
                 :no-data-text="isSearching ? 'Searching...' : 'No players found'"
                 @update:search-input="onSearchInput"
-                @change="clear"
+                @change="onChange"
             >
                 <template v-slot:item="data">
                     <v-list-item-avatar>
@@ -144,9 +144,9 @@ export default class PlayerFilter extends Vue {
         }
     }
 
-    clear() {
-        (this.$refs.vAutocomplete as any).lazySearch = ""; // temp fix for last text not clearing, fixed in latest vuetify
-        this.$emit("input", this.selectedItems);
+    onChange() {
+        (this.$refs.vAutocomplete as any).isMenuActive = false;
+        this.$emit("input", this.selectedItems?.length ? this.selectedItems : undefined);
     }
 }
 </script>

--- a/utils/coerce-object.ts
+++ b/utils/coerce-object.ts
@@ -1,6 +1,7 @@
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
 import _ from "lodash";
+import { IntersectKind } from "@sinclair/typebox";
 
 const ajv = addFormats(new Ajv({
     coerceTypes: "array",
@@ -8,31 +9,53 @@ const ajv = addFormats(new Ajv({
     strict: false,
     useDefaults: true
 }), [
-    'date-time',
-    'time',
-    'date',
-    'email',
-    'hostname',
-    'ipv4',
-    'ipv6',
-    'uri',
-    'uri-reference',
-    'uuid',
-    'uri-template',
-    'json-pointer',
-    'relative-json-pointer',
-    'regex'
-]).addKeyword('kind').addKeyword('modifier');
+    "date-time",
+    "time",
+    "date",
+    "email",
+    "hostname",
+    "ipv4",
+    "ipv6",
+    "uri",
+    "uri-reference",
+    "uuid",
+    "uri-template",
+    "json-pointer",
+    "relative-json-pointer",
+    "regex"
+]).addKeyword("kind").addKeyword("modifier");
 
-export function coerceObjectFactory(schema: any) {
-    const validate = ajv.compile(schema);
+export function coerceObjectFactory(schemas: any) {
+    const validate = ajv.compile(schemas);
 
-    return function (obj: any): any {
+    // Normalize schemas to an array to make it easier to handle later
+    if (schemas.kind === IntersectKind) {
+        schemas = schemas.allOf;
+    } else {
+        schemas = [schemas];
+    }
+
+    return function(obj: any): any {
         const data = _.cloneDeep(obj);
+
+        // Handle comma separated query params
+        for (const [key, value] of Object.entries(data)) {
+            if (typeof value !== "string" || !value.includes(",")) {
+                continue;
+            }
+            const isArray = schemas.some(
+                (schemaPart: any) => schemaPart.properties?.[key]?.type === "array"
+            );
+
+            if (isArray) {
+                data[key] = value.split(",");
+            }
+        }
+
         validate(data);
         if (validate.errors && validate.errors.length) {
             console.log(validate.errors);
         }
         return data;
-    }
+    };
 }


### PR DESCRIPTION
The issue:
If I add something to player or map filter 
<img width="1382" height="175" alt="image" src="https://github.com/user-attachments/assets/e6083458-fb7c-4ea7-84dc-371ff605aa8a" />
and then I clear it, it leaves empty query params in the url:
<img width="697" height="44" alt="image" src="https://github.com/user-attachments/assets/90d002e1-b56a-4558-9879-130ce3c38b04" />
It's a problem because if I refresh the page or send this link to someone, it won't show any replays - it tries to find players/maps with empty name



Fix is more like a guess because I can't replicate the issue locally. My reasoning is that isEnabled emits 'undefined' when filter is disabled and it works fine - the queryParams get cleared. So I assume that sending 'undefined' should also help in onChange. Also got rid of 'temp fix' in onChange - hiding the drop-down menu makes text disappear so it wasn't required anymore. I think that this "temp fix" could also be the cause of the issue but I'm unable to check that. 


Edit:
I pushed one more commit, to handle links like this one:
`https://www.beyondallreason.info/replays?page=1&limit=24&hasBots=false&endedNormally=true&players=Drongo%2CLucyGoesAir`

The issue is that players uses comma separated list instead of repeated keys (players=Drongo&players=LucyGoesAir)
I added some logic which checks if the param should be an array and splits it if it contains a comma



LLM Usage:
I used LLM to find where the comma separated params broke the code and to simplify the splitting logic