### PR TITLE
Sort the player filter items so the exact match is prioritized

### DIFF
--- a/pages/replays/components/PlayerFilter.vue
+++ b/pages/replays/components/PlayerFilter.vue
@@ -86,6 +86,28 @@ export default class PlayerFilter extends Vue {
             const matchingItems = this.allItems.filter((item) => {
                 return item.username.toLowerCase().includes(search);
             });
+
+            matchingItems.sort((a, b) => {
+                const aName = a.username.toLowerCase();
+                const bName = b.username.toLowerCase();
+
+                if (aName === search) {
+                    return -1;
+                }
+                if (bName === search) {
+                    return 1;
+                }
+
+                const isPrefixOfA = aName.startsWith(search);
+                const isPrefixOfB = bName.startsWith(search);
+
+                if (isPrefixOfA !== isPrefixOfB) {
+                    return isPrefixOfA ? -1 : 1;
+                }
+
+                return aName.localeCompare(bName);
+            });
+
             filteredItems = matchingItems.slice(0, 50); // Limit to 50 results for performance
         }
 


### PR DESCRIPTION
I noticed that some players couldn't be filtered by on the replay page, because their name never appeared on the list. This change sorts the names, so the exact match and names starting with the search term, come first

Before:
<img width="560" height="431" alt="image" src="https://github.com/user-attachments/assets/bfc49a43-311f-45d2-bf9f-105feadee767" />

After:
<img width="503" height="461" alt="image" src="https://github.com/user-attachments/assets/44a5aff2-6c1a-441c-a8fc-7ea3ad088eff" />
