### PR TITLE
bar-live-services: vue testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7038,16 +7038,6 @@
       "resolved": "http://verdaccio.slot.works:4873/@types%2fstack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw=="
     },
-    "@types/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "http://verdaccio.slot.works:4873/@types%2fstrip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I="
-    },
-    "@types/strip-json-comments": {
-      "version": "0.0.30",
-      "resolved": "http://verdaccio.slot.works:4873/@types%2fstrip-json-comments/-/strip-json-comments-0.0.30.tgz",
-      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ=="
-    },
     "@types/tapable": {
       "version": "1.0.6",
       "resolved": "http://verdaccio.slot.works:4873/@types%2ftapable/-/tapable-1.0.6.tgz",
@@ -9235,58 +9225,6 @@
         }
       }
     },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "http://verdaccio.slot.works:4873/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "http://verdaccio.slot.works:4873/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "http://verdaccio.slot.works:4873/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://verdaccio.slot.works:4873/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "http://verdaccio.slot.works:4873/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "http://verdaccio.slot.works:4873/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "http://verdaccio.slot.works:4873/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
-      }
-    },
     "babel-eslint": {
       "version": "10.1.0",
       "resolved": "http://verdaccio.slot.works:4873/babel-eslint/-/babel-eslint-10.1.0.tgz",
@@ -9371,14 +9309,6 @@
         "schema-utils": "^2.6.5"
       }
     },
-    "babel-messages": {
-      "version": "6.23.0",
-      "resolved": "http://verdaccio.slot.works:4873/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "http://verdaccio.slot.works:4873/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
@@ -9444,26 +9374,6 @@
         "@babel/helper-define-polyfill-provider": "^0.2.2"
       }
     },
-    "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.26.2",
-      "resolved": "http://verdaccio.slot.works:4873/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-      "requires": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
-      }
-    },
-    "babel-plugin-transform-strict-mode": {
-      "version": "6.24.1",
-      "resolved": "http://verdaccio.slot.works:4873/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
     "babel-preset-current-node-syntax": {
       "version": "1.0.1",
       "resolved": "http://verdaccio.slot.works:4873/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
@@ -9491,85 +9401,6 @@
         "babel-plugin-jest-hoist": "^26.6.2",
         "babel-preset-current-node-syntax": "^1.0.0"
       }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "http://verdaccio.slot.works:4873/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.10",
-          "resolved": "http://verdaccio.slot.works:4873/core-js/-/core-js-2.6.10.tgz",
-          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
-        },
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "http://verdaccio.slot.works:4873/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-        }
-      }
-    },
-    "babel-template": {
-      "version": "6.26.0",
-      "resolved": "http://verdaccio.slot.works:4873/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "http://verdaccio.slot.works:4873/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
-      },
-      "dependencies": {
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "http://verdaccio.slot.works:4873/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-        }
-      }
-    },
-    "babel-types": {
-      "version": "6.26.0",
-      "resolved": "http://verdaccio.slot.works:4873/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
-      },
-      "dependencies": {
-        "to-fast-properties": {
-          "version": "1.0.3",
-          "resolved": "http://verdaccio.slot.works:4873/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
-        }
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "http://verdaccio.slot.works:4873/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -11082,11 +10913,6 @@
         }
       }
     },
-    "clone": {
-      "version": "2.1.2",
-      "resolved": "http://verdaccio.slot.works:4873/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
-    },
     "clone-deep": {
       "version": "4.0.1",
       "resolved": "http://verdaccio.slot.works:4873/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -11545,6 +11371,7 @@
       "version": "2.2.4",
       "resolved": "http://verdaccio.slot.works:4873/css/-/css-2.2.4.tgz",
       "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "source-map": "^0.6.1",
@@ -11831,15 +11658,6 @@
       "version": "1.0.2",
       "resolved": "http://verdaccio.slot.works:4873/de-indent/-/de-indent-1.0.2.tgz",
       "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0="
-    },
-    "deasync": {
-      "version": "0.1.21",
-      "resolved": "http://verdaccio.slot.works:4873/deasync/-/deasync-0.1.21.tgz",
-      "integrity": "sha512-kUmM8Y+PZpMpQ+B4AuOW9k2Pfx/mSupJtxOsLzmnHY2WqZUYRFccFn2RhzPAqt3Xb+sorK/badW2D4zNzqZz5w==",
-      "requires": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^1.7.1"
-      }
     },
     "debug": {
       "version": "2.6.9",
@@ -13670,8 +13488,9 @@
     },
     "extract-from-css": {
       "version": "0.4.4",
-      "resolved": "http://verdaccio.slot.works:4873/extract-from-css/-/extract-from-css-0.4.4.tgz",
-      "integrity": "sha1-HqffLnx8brmSL6COitrqSG9vj5I=",
+      "resolved": "https://registry.npmjs.org/extract-from-css/-/extract-from-css-0.4.4.tgz",
+      "integrity": "sha512-41qWGBdtKp9U7sgBxAQ7vonYqSXzgW/SiAYzq4tdWSVhAShvpVCH1nyvPQgjse6EdgbW7Y7ERdT3674/lKr65A==",
+      "dev": true,
       "requires": {
         "css": "^2.1.0"
       }
@@ -14073,27 +13892,6 @@
         "parseurl": "~1.3.3",
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
-      }
-    },
-    "find-babel-config": {
-      "version": "1.2.0",
-      "resolved": "http://verdaccio.slot.works:4873/find-babel-config/-/find-babel-config-1.2.0.tgz",
-      "integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
-      "requires": {
-        "json5": "^0.5.1",
-        "path-exists": "^3.0.0"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "0.5.1",
-          "resolved": "http://verdaccio.slot.works:4873/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "http://verdaccio.slot.works:4873/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-        }
       }
     },
     "find-cache-dir": {
@@ -15613,14 +15411,6 @@
             "has-flag": "^4.0.0"
           }
         }
-      }
-    },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "http://verdaccio.slot.works:4873/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "ioredis": {
@@ -18015,14 +17805,6 @@
         }
       }
     },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "http://verdaccio.slot.works:4873/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
     "lower-case": {
       "version": "2.0.2",
       "resolved": "http://verdaccio.slot.works:4873/lower-case/-/lower-case-2.0.2.tgz",
@@ -18555,20 +18337,6 @@
             "lru-cache": "^6.0.0"
           }
         }
-      }
-    },
-    "node-addon-api": {
-      "version": "1.7.2",
-      "resolved": "http://verdaccio.slot.works:4873/node-addon-api/-/node-addon-api-1.7.2.tgz",
-      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
-    },
-    "node-cache": {
-      "version": "4.2.1",
-      "resolved": "http://verdaccio.slot.works:4873/node-cache/-/node-cache-4.2.1.tgz",
-      "integrity": "sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==",
-      "requires": {
-        "clone": "2.x",
-        "lodash": "^4.17.15"
       }
     },
     "node-fetch": {
@@ -24704,24 +24472,6 @@
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw=="
     },
-    "tsconfig": {
-      "version": "7.0.0",
-      "resolved": "http://verdaccio.slot.works:4873/tsconfig/-/tsconfig-7.0.0.tgz",
-      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
-      "requires": {
-        "@types/strip-bom": "^3.0.0",
-        "@types/strip-json-comments": "0.0.30",
-        "strip-bom": "^3.0.0",
-        "strip-json-comments": "^2.0.0"
-      },
-      "dependencies": {
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "http://verdaccio.slot.works:4873/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-        }
-      }
-    },
     "tsconfig-paths": {
       "version": "3.9.0",
       "resolved": "http://verdaccio.slot.works:4873/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
@@ -25356,37 +25106,23 @@
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog=="
     },
     "vue-jest": {
-      "version": "3.0.7",
-      "resolved": "http://verdaccio.slot.works:4873/vue-jest/-/vue-jest-3.0.7.tgz",
-      "integrity": "sha512-PIOxFM+wsBMry26ZpfBvUQ/DGH2hvp5khDQ1n51g3bN0TwFwTy4J85XVfxTRMukqHji/GnAoGUnlZ5Ao73K62w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/vue-jest/-/vue-jest-4.0.1.tgz",
+      "integrity": "sha512-4jewjN8HVgpIW0ZdEwzCWz5vcRLIs1PxMs+5IqJ/6f9KRbEQ+DEqEKHUzIjoNzW2UJOUYBZzWpBnVHakpc/k5w==",
+      "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.2.0",
+        "@vue/component-compiler-utils": "^3.1.0",
         "chalk": "^2.1.0",
-        "deasync": "^0.1.15",
         "extract-from-css": "^0.4.4",
-        "find-babel-config": "^1.1.0",
-        "js-beautify": "^1.6.14",
-        "node-cache": "^4.1.1",
-        "object-assign": "^4.1.1",
-        "source-map": "^0.5.6",
-        "tsconfig": "^7.0.0",
-        "vue-template-es2015-compiler": "^1.6.0"
+        "source-map": "0.5.6"
       },
       "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "http://verdaccio.slot.works:4873/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
         "source-map": {
-          "version": "0.5.7",
-          "resolved": "http://verdaccio.slot.works:4873/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -48,12 +48,14 @@
         "nuxt-property-decorator": "^2.9.1",
         "sass": "^1.32.5",
         "sass-loader": "^10.1.1",
-        "three": "latest",
+        "three": "^0.179.1",
         "ts-jest": "^26.4.1",
         "ufo": "^0.7.9",
         "vue-class-component": "^7.2.6",
-        "vue-jest": "^3.0.4",
         "vue-property-decorator": "^9.1.2",
         "vuex-module-decorators": "^1.0.1"
+    },
+    "devDependencies": {
+        "vue-jest": "^4.0.1"
     }
 }

--- a/test/replays/PlayerFilter.test.ts
+++ b/test/replays/PlayerFilter.test.ts
@@ -1,0 +1,125 @@
+import { mount, createLocalVue } from "@vue/test-utils";
+import Vuetify from "vuetify";
+import Vue from "vue";
+// @ts-ignore
+import PlayerFilter from "@/pages/replays/components/PlayerFilter.vue";
+
+Vue.use(Vuetify);
+
+const localVue = createLocalVue();
+
+describe("PlayerFilter.vue", () => {
+    let vuetify: Vuetify;
+
+    beforeEach(() => {
+        vuetify = new Vuetify();
+    });
+
+    const mockPlayers = [
+        { id: 1, username: "alice" },
+        { id: 2, username: "Alix" },
+        { id: 3, username: "bob" },
+        { id: 4, username: "bobby" },
+        { id: 5, username: "carol" },
+        { id: 6, username: "ally" },
+        { id: 7, username: "xalicex" },
+        { id: 8, username: "  spaced  " } // included to show trim is on search text, not usernames
+    ];
+
+    const factory = (propsData = {}, mocks = {}) => {
+        return mount(PlayerFilter, {
+            localVue,
+            vuetify,
+            propsData: {
+                ...propsData
+            },
+            mocks: {
+                $axios: {
+                    $get: jest.fn().mockResolvedValue(mockPlayers)
+                },
+                ...mocks
+            },
+            stubs: {
+                "v-autocomplete": true,
+                "v-icon": true,
+                "v-list-item-avatar": true,
+                "v-list-item-content": true,
+                "v-list-item-title": true
+            }
+        });
+    };
+
+    it("should initialize with default props", () => {
+        const wrapper = factory();
+        expect(wrapper.props().value).toEqual([]);
+        expect(wrapper.props().enabled).toBe(true);
+    });
+
+    it("should toggle isEnabled when clicking on the name", async() => {
+        const wrapper = factory();
+        const nameDiv = wrapper.find(".name");
+
+        expect(wrapper.vm.$data.isEnabled).toBe(true);
+        await nameDiv.trigger("click");
+        expect(wrapper.vm.$data.isEnabled).toBe(false);
+        await nameDiv.trigger("click");
+        expect(wrapper.vm.$data.isEnabled).toBe(true);
+    });
+
+    it("should fetch players on fetch call", async() => {
+        const wrapper = factory();
+        const vm = wrapper.vm as any;
+
+        await vm.$options.fetch.call(vm);
+
+        expect(vm.allItems).toEqual(mockPlayers);
+        expect(vm.itemsForAutocomplete).toHaveLength(mockPlayers.length);
+    });
+
+    it("should emit input event when isEnabled changes", async() => {
+        const wrapper = factory();
+        const vm = wrapper.vm as any;
+
+        vm.isEnabled = false;
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.emitted().input).toBeTruthy();
+        expect(wrapper.emitted().input![0]).toEqual([undefined]);
+
+        vm.isEnabled = true;
+        await wrapper.vm.$nextTick();
+        expect(wrapper.emitted().input![1]).toEqual([[]]);
+    });
+
+    it("should filter items based on search text", async() => {
+        const wrapper = factory();
+        const vm = wrapper.vm as any;
+        vm.allItems = mockPlayers;
+
+        // Directly call filterItems to avoid debounce in this test or use jest.useFakeTimers()
+        vm.filterItems("al");
+
+        expect(vm.itemsForAutocomplete.map((i: any) => i.username)).toEqual<Array<string>>(["alice", "Alix", "ally", "xalicex"]);
+    });
+
+    it("should handle countryImage with dynamic require mock", () => {
+        const wrapper = factory();
+        const vm = wrapper.vm as any;
+
+        const img = vm.countryImage("us");
+        expect(typeof img).toBe("string");
+    });
+
+    it("should clear search input and emit change on clear", async() => {
+        const wrapper = factory();
+        const vm = wrapper.vm as any;
+
+        // Mock the ref
+        vm.$refs.vAutocomplete = { lazySearch: "some text" };
+
+        vm.clear();
+
+        expect(vm.$refs.vAutocomplete.lazySearch).toBe("");
+        expect(wrapper.emitted().input).toBeTruthy();
+    });
+});


### PR DESCRIPTION
- add testing of vue components; 
- move vue-jest to dev deps and bump to v4; 
- add PlayerFilter.test.ts with first tests; 
- set fixed version 0.179.1 for three.js so build will work after new packages are installed;

<img width="496" height="242" alt="image" src="https://github.com/user-attachments/assets/53ed374c-ed42-4eac-b7e6-0c898f057534" />

Note: tests are not enabled for now not to block due to missing tests, and are not linked with github (never done that)

LLM Usage: binding vue-jest tests with Vue2/Nuxt2 with very sparse docs from that time, asked for help and got a working answer

Edit: LLM disclosure and note about tests being suppressed and not linked with github